### PR TITLE
Fix: Use answer type if exists

### DIFF
--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -271,7 +271,20 @@ class Server
                     // Add answers section
                     foreach ($answers as $answer) {
                         $response .= \chr(192) . \chr(12); // 192 indicates this is pointer, 12 is offset to question.
-                        $response .= \pack('nn', $typeByte, $classByte);
+                        $answerTypeByte = match ($answer->getTypeName()) {
+                            'A' => 1,
+                            'CNAME' => 5,
+                            'MX' => 15,
+                            'TXT' => 16,
+                            'AAAA' => 28,
+                            'SRV' => 33,
+                            'CAA' => 257,
+                            'NS' => 2,
+                            default => $typeByte // Fallback to question type if unknown
+                        };
+
+                        // Pack the answer's type, not the question type
+                        $response .= \pack('nn', $answerTypeByte, $classByte);
 
                         /**
                          * @var string $type

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -271,20 +271,9 @@ class Server
                     // Add answers section
                     foreach ($answers as $answer) {
                         $response .= \chr(192) . \chr(12); // 192 indicates this is pointer, 12 is offset to question.
-                        $answerTypeByte = match ($answer->getTypeName()) {
-                            'A' => 1,
-                            'CNAME' => 5,
-                            'MX' => 15,
-                            'TXT' => 16,
-                            'AAAA' => 28,
-                            'SRV' => 33,
-                            'CAA' => 257,
-                            'NS' => 2,
-                            default => $typeByte // Fallback to question type if unknown
-                        };
 
                         // Pack the answer's type, not the question type
-                        $response .= \pack('nn', $answerTypeByte, $classByte);
+                        $response .= \pack('nn', $answer->getType(), $classByte);
 
                         /**
                          * @var string $type

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -289,7 +289,7 @@ class Server
                         /**
                          * @var string $type
                          */
-                        $type = $answer->getTypeName() ?? $question['type'];
+                        $type = $answer->getTypeName();
 
                         $response .= match ($type) {
                             'A' => $this->encodeIP($answer->getRdata(), $answer->getTTL()),

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -276,7 +276,7 @@ class Server
                         /**
                          * @var string $type
                          */
-                        $type = $question['type'];
+                        $type = $answer->getTypeName() ?? $question['type'];
 
                         $response .= match ($type) {
                             'A' => $this->encodeIP($answer->getRdata(), $answer->getTTL()),


### PR DESCRIPTION
- Because resolver can Fallback in case of A  record, if not found fallback to CNAME record, always using question type causes failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - DNS responses now accurately reflect the actual record types of answers, ensuring improved compatibility and correctness when handling various DNS records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->