### PR TITLE
Fix: encoding decoding of CAA records

### DIFF
--- a/src/DNS/Record.php
+++ b/src/DNS/Record.php
@@ -136,6 +136,7 @@ class Record
                 'TXT'   => 16,
                 'AAAA'  => 28,
                 'SRV'   => 33,
+                'CAA'   => 257,
             ];
             $upper = strtoupper($type);
             $this->type = $map[$upper] ?? 0;
@@ -321,6 +322,7 @@ class Record
             16 => 'TXT',
             28 => 'AAAA',
             33 => 'SRV',
+            257 => 'CAA',
         ];
         return $types[$this->type] ?? "TYPE{$this->type}";
     }

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -427,6 +427,13 @@ class Server
         return $result;
     }
 
+    /**
+     * Encode a CAA record according to RFC 6844.
+     *
+     * @param array{flags?:int,tag?:string,value?:string}|string $rdata
+     * @param int $ttl
+     * @return string
+     */
     protected function encodeCAA(array|string $rdata, int $ttl): string
     {
         $flags = 0;

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -173,35 +173,38 @@ class Server
                     // Parse question domain
                     $domain = "";
                     $offset = 12;
-                    while ($offset < \strlen($buffer)) {
-                        // Get label length
-                        $labelLength = \ord($buffer[$offset]);
-
+                    while ($offset < strlen($buffer)) {
+                        // Check for at least 1 byte for label length
+                        if (($offset + 1) > strlen($buffer)) {
+                            throw new \Exception('Malformed packet: not enough bytes for label length');
+                        }
+                        $labelLength = ord($buffer[$offset]);
                         Console::info("[PACKET] Processing label at offset {$offset}, length: {$labelLength}");
-
-                        // End of question
-                        if ($labelLength === 0 && \ord($buffer[$offset + 1]) === 0) {
-                            Console::info("[PACKET] End of domain name found at offset " . ($offset + 1));
+                        // End of question (zero label)
+                        if ($labelLength === 0) {
                             $offset += 1;
+                            Console::info("[PACKET] End of domain name found at offset " . ($offset));
                             break;
                         }
-
-                        // Extract label as string
-                        $label = \substr($buffer, $offset + 1, $labelLength);
+                        // Check for enough bytes for label
+                        if (($offset + 1 + $labelLength) > strlen($buffer)) {
+                            throw new \Exception('Malformed packet: not enough bytes for label');
+                        }
+                        $label = substr($buffer, $offset + 1, $labelLength);
                         Console::info("[PACKET] Found label: {$label}");
-
                         if (empty($domain)) {
                             $domain .= $label;
                         } else {
                             $domain .= '.' . $label;
                         }
-
                         // Skip to next label length
                         $offset += 1 + $labelLength;
                     }
-
-                    // Parse question type
-                    $unpacked = \unpack('ntype/nclass', \substr($buffer, $offset, 4));
+                    // After domain, there should be 4 bytes for type/class
+                    if (($offset + 4) > strlen($buffer)) {
+                        throw new \Exception('Malformed packet: not enough bytes for question type/class');
+                    }
+                    $unpacked = unpack('ntype/nclass', substr($buffer, $offset, 4));
                     $offset += 4;
                     $typeByte = $unpacked['type'] ?? 0;
                     $classByte = $unpacked['class'] ?? 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the CAA DNS record type, allowing users to set and retrieve CAA records.

* **Bug Fixes**
  * Improved DNS packet parsing with additional boundary checks to enhance stability and prevent errors from malformed packets.

* **Other**
  * Enhanced encoding for CAA records in DNS responses, ensuring proper handling and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->