### PR TITLE
Fix: improve encoder functions according to RFC

### DIFF
--- a/src/DNS/Client.php
+++ b/src/DNS/Client.php
@@ -230,12 +230,7 @@ class Client
                     $txts[] = $chunk;
                     $offset += $len;
                 }
-                // If you want to match dig output, wrap in quotes and escape embedded quotes
-                $txtValue = implode('', $txts);
-                if (strpos($txtValue, '"') !== false) {
-                    $txtValue = str_replace('"', '\\"', $txtValue);
-                }
-                return '"' . $txtValue . '"';
+                return implode('', $txts);
             case 33: // SRV record
                 $priority = unpack('n', substr($packet, $offset, 2));
                 $weight = unpack('n', substr($packet, $offset + 2, 2));

--- a/src/DNS/Client.php
+++ b/src/DNS/Client.php
@@ -226,10 +226,15 @@ class Client
                 while ($offset < $end) {
                     $len = ord($packet[$offset]);
                     $offset++;
-                    $txts[] = substr($packet, $offset, $len);
+                    if ($len > 0) {
+                        $txts[] = substr($packet, $offset, $len);
+                    } else {
+                        $txts[] = '';
+                    }
                     $offset += $len;
                 }
-                return implode(' ', $txts);
+                // Concatenate chunks directly, no separator
+                return implode('', $txts);
             case 33: // SRV record
                 $priority = unpack('n', substr($packet, $offset, 2));
                 $weight = unpack('n', substr($packet, $offset + 2, 2));

--- a/src/DNS/Client.php
+++ b/src/DNS/Client.php
@@ -226,15 +226,16 @@ class Client
                 while ($offset < $end) {
                     $len = ord($packet[$offset]);
                     $offset++;
-                    if ($len > 0) {
-                        $txts[] = substr($packet, $offset, $len);
-                    } else {
-                        $txts[] = '';
-                    }
+                    $chunk = ($len > 0) ? substr($packet, $offset, $len) : '';
+                    $txts[] = $chunk;
                     $offset += $len;
                 }
-                // Concatenate chunks directly, no separator
-                return implode('', $txts);
+                // If you want to match dig output, wrap in quotes and escape embedded quotes
+                $txtValue = implode('', $txts);
+                if (strpos($txtValue, '"') !== false) {
+                    $txtValue = str_replace('"', '\\"', $txtValue);
+                }
+                return '"' . $txtValue . '"';
             case 33: // SRV record
                 $priority = unpack('n', substr($packet, $offset, 2));
                 $weight = unpack('n', substr($packet, $offset + 2, 2));

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -10,7 +10,7 @@ use Utopia\Telemetry\Counter;
 use Utopia\Telemetry\Histogram;
 
 /**
- * Refference about DNS packet:
+ * Reference about DNS packet:
  *
  * HEADER
  * > 16 bits identificationField (1-65535. 0 means no ID). ID provided by client. Helps to match async responses. Usage may allow DNS Cache Poisoning
@@ -29,7 +29,7 @@ use Utopia\Telemetry\Histogram;
  * > 16 bits numberOfAdditionals (0-65535)
  *
  * QUESTIONS SECTION
- * > Each question contians:
+ * > Each question contains:
  * > -- dynamic-length name. Includes domain name we are looking for. Split into labels. To get domain, join labels with dot symbol.
  * > -- -- Following pattern repeats:
  * > -- -- -- 8 bits labelLength (0-255). Defines length of label. We use it in next step
@@ -42,12 +42,18 @@ use Utopia\Telemetry\Histogram;
  * ANSWERS SECTION
  * > Follows same pattern as questions section.
  * > Each answer also has (at the end):
- * > -- 32 bits ttl. Time to live of the naswer
+ * > -- 32 bits ttl. Time to live of the answer
  * > -- 16 bit length. Length of the answer data.
  * > -- X bits data X length is length from above. Gives answer itself. Structure changes based on type.
  *
  * AUTHORITIES SECTION
  * ADDITIONALS SECTION
+ *
+ * RFCs:
+ * - RFC 1035: https://datatracker.ietf.org/doc/html/rfc1035
+ * - RFC 3596: https://datatracker.ietf.org/doc/html/rfc3596
+ * - RFC 6844: https://datatracker.ietf.org/doc/html/rfc6844
+ * - RFC 2782: https://datatracker.ietf.org/doc/html/rfc2782
  */
 
 class Server
@@ -343,6 +349,7 @@ class Server
 
     /**
      * Encode an IPv4 address (A record) according to RFC 1035.
+     * @see https://datatracker.ietf.org/doc/html/rfc1035
      *
      * @param string $ip
      * @param int $ttl
@@ -360,6 +367,7 @@ class Server
 
     /**
      * Encode an IPv6 address (AAAA record) according to RFC 3596.
+     * @see https://datatracker.ietf.org/doc/html/rfc3596
      *
      * @param string $ip
      * @param int $ttl
@@ -377,6 +385,7 @@ class Server
 
     /**
      * Encode a domain name (CNAME, NS, PTR) according to RFC 1035.
+     * @see https://datatracker.ietf.org/doc/html/rfc1035
      *
      * @param string $domain
      * @param int $ttl
@@ -409,6 +418,7 @@ class Server
 
     /**
      * Encode a TXT record according to RFC 1035.
+     * @see https://datatracker.ietf.org/doc/html/rfc1035
      *
      * @param string $text
      * @param int $ttl
@@ -429,6 +439,7 @@ class Server
 
     /**
      * Encode an MX record according to RFC 1035.
+     * @see https://datatracker.ietf.org/doc/html/rfc1035
      *
      * @param string $domain
      * @param int $ttl
@@ -459,6 +470,7 @@ class Server
 
     /**
      * Encode an SRV record according to RFC 2782.
+     * @see https://datatracker.ietf.org/doc/html/rfc2782
      *
      * @param string $domain
      * @param int $ttl
@@ -504,6 +516,7 @@ class Server
 
     /**
      * Encode a CAA record according to RFC 6844.
+     * @see https://datatracker.ietf.org/doc/html/rfc6844
      *
      * @param array{flags?:int,tag?:string,value?:string}|string $rdata
      * @param int $ttl

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -378,6 +378,9 @@ class Server
         $totalLength = 0;
         foreach ($labels as $label) {
             $labelLength = strlen($label);
+            if ($labelLength === 0) {
+                throw new \Exception("Empty label in domain: '{$domain}'");
+            }
             if ($labelLength > 63) {
                 throw new \Exception("Label too long in domain: {$label}");
             }
@@ -449,11 +452,24 @@ class Server
      */
     protected function encodeSrv(string $domain, int $ttl, int $priority, int $weight, int $port): string
     {
+        // Validate SRV parameters
+        if ($priority < 0 || $priority > 65535) {
+            throw new \Exception("SRV priority out of range: {$priority}");
+        }
+        if ($weight < 0 || $weight > 65535) {
+            throw new \Exception("SRV weight out of range: {$weight}");
+        }
+        if ($port < 0 || $port > 65535) {
+            throw new \Exception("SRV port out of range: {$port}");
+        }
         $labels = explode('.', rtrim($domain, '.'));
         $result = pack('nnn', $priority, $weight, $port);
         $totalLength = 6;
         foreach ($labels as $label) {
             $labelLength = strlen($label);
+            if ($labelLength === 0) {
+                throw new \Exception("Empty label in SRV domain: '{$domain}'");
+            }
             if ($labelLength > 63) {
                 throw new \Exception("Label too long in SRV domain: {$label}");
             }

--- a/src/DNS/Zone.php
+++ b/src/DNS/Zone.php
@@ -181,8 +181,11 @@ class Zone
             // For TXT records, only strip comments at #, not at semicolons
             $isTxt = false;
             $peekTokens = $this->tokenize($rawLine);
-            if (count($peekTokens) >= 4 && strtoupper($peekTokens[3]) === 'TXT') {
-                $isTxt = true;
+            foreach ($peekTokens as $tok) {
+                if (strtoupper($tok) === 'TXT') {
+                    $isTxt = true;
+                    break;
+                }
             }
             if ($isTxt) {
                 $line = trim($this->stripTrailingComment($rawLine, true));
@@ -374,8 +377,17 @@ class Zone
         $result = '';
         for ($i = 0, $len = strlen($line); $i < $len; $i++) {
             $c = $line[$i];
+            // Check for unescaped quote
             if ($c === '"') {
-                $inQuote = !$inQuote;
+                $escaped = false;
+                $j = $i - 1;
+                while ($j >= 0 && $line[$j] === '\\') {
+                    $escaped = !$escaped;
+                    $j--;
+                }
+                if (!$escaped) {
+                    $inQuote = !$inQuote;
+                }
             }
             if (!$inQuote && ($c === '#' || (!$txtMode && $c === ';'))) {
                 break;

--- a/src/DNS/Zone.php
+++ b/src/DNS/Zone.php
@@ -219,7 +219,14 @@ class Zone
             }
             $type = strtoupper($tokens[$pos++]);
             $dataParts = array_slice($tokens, $pos);
-            $data = implode(' ', $dataParts);
+            if ($type === 'TXT') {
+                $data = '';
+                foreach ($dataParts as $part) {
+                    $data .= $part;
+                }
+            } else {
+                $data = implode(' ', $dataParts);
+            }
             if ($owner !== '@' && !str_ends_with($owner, '.')) {
                 $owner .= '.' . rtrim($this->defaultOrigin, '.');
             }

--- a/tests/DNS/ClientTest.php
+++ b/tests/DNS/ClientTest.php
@@ -105,9 +105,10 @@ class ClientTest extends TestCase
 
         $records = $this->client->query('dev2.appwrite.io', 'TXT');
 
-        $this->assertCount(2, $records);
+        $this->assertCount(3, $records);
         $this->assertEquals('key with "$\'- symbols', $records[0]->getRdata());
         $this->assertEquals('key with spaces', $records[1]->getRdata());
+        $this->assertEquals('v=DMARC1; p=none; rua=mailto:jon@snow.got; ruf=mailto:jon@snow.got; fo=1;', $records[2]->getRdata());
 
         $records = $this->client->query('dev3.appwrite.io', 'TXT');
         $this->assertCount(0, $records);

--- a/tests/DNS/ServerMemory.php
+++ b/tests/DNS/ServerMemory.php
@@ -60,6 +60,10 @@ $resolver->addRecord('dev2.appwrite.io', 'TXT', [
     'value' => 'key with spaces'
 ]);
 
+$resolver->addRecord('dev2.appwrite.io', 'TXT', [
+    'value' => 'v=DMARC1; p=none; rua=mailto:jon@snow.got; ruf=mailto:jon@snow.got; fo=1;'
+]);
+
 $resolver->addRecord('dev.appwrite.io', 'CAA', [
     'value' => 'issue "letsencrypt.org"',
     'ttl' => 50

--- a/tests/DNS/ZoneTest.php
+++ b/tests/DNS/ZoneTest.php
@@ -338,7 +338,7 @@ ZONE;
         $this->assertSame($records1[2]->getRdata(), $records2[2]->getRdata());
     }
 
-     public function testImportTxtWithSpecialChars()
+     public function testImportTxtWithSpecialChars(): void
      {
          $zone = new Zone();
          $zonefile = <<<ZONE
@@ -350,4 +350,14 @@ ZONE;
          $this->assertEquals('TXT', $rec->getTypeName());
          $this->assertEquals('v=DMARC1; p=none; rua=mailto:jon@snow.got; ruf=mailto:jon@snow.got; fo=1;', trim($rec->getRdata(), '"'));
      }
+
+    public function testExportTxtWithSpecialChars(): void
+    {
+        $zone = new Zone();
+        $txt = 'v=DMARC1; p=none; rua=mailto:jon@snow.got; ruf=mailto:jon@snow.got; fo=1; text="quoted"; backslash=\\';
+        $rec = new Record('@', 3600, 'IN', 'TXT', $txt);
+        $exported = $zone->export('example.com', [$rec]);
+        $expected = '@ 3600 IN TXT "v=DMARC1; p=none; rua=mailto:jon@snow.got; ruf=mailto:jon@snow.got; fo=1; text=\\"quoted\\"; backslash=\\\\"' . "\n";
+        $this->assertSame($expected, $exported);
+    }
 }

--- a/tests/DNS/ZoneTest.php
+++ b/tests/DNS/ZoneTest.php
@@ -337,4 +337,17 @@ ZONE;
         $this->assertSame($records1[2]->getPriority(), $records2[2]->getPriority());
         $this->assertSame($records1[2]->getRdata(), $records2[2]->getRdata());
     }
+
+     public function testImportTxtWithSpecialChars()
+     {
+         $zone = new Zone();
+         $zonefile = <<<ZONE
+@ 3600 IN TXT "v=DMARC1; p=none; rua=mailto:jon@snow.got; ruf=mailto:jon@snow.got; fo=1;"
+ZONE;
+         $records = $zone->import('example.com', $zonefile);
+         $this->assertCount(1, $records);
+         $rec = $records[0];
+         $this->assertEquals('TXT', $rec->getTypeName());
+         $this->assertEquals('v=DMARC1; p=none; rua=mailto:jon@snow.got; ruf=mailto:jon@snow.got; fo=1;', trim($rec->getRdata(), '"'));
+     }
 }


### PR DESCRIPTION
- Improve encoder functions
- Improve zone export/import handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS record encoding for IPv4, IPv6, domain, TXT, MX, SRV, and CAA types with enhanced validation and RFC compliance.
  * Enhanced DNS zone file parsing and tokenization to properly handle quoted strings, escape sequences, and comment stripping, especially for TXT records.
  * Refined TXT record parsing to handle empty chunks and concatenate text without extra spaces.
* **Tests**
  * Updated TXT record tests to include additional DMARC policy validation for improved coverage.
  * Added new tests for importing and exporting TXT records with special characters and quoted strings.
* **Chores**
  * Added new TXT DNS record with DMARC policy to the memory resolver for extended test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->