### PR TITLE
Add CAA record to Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,11 @@
         "laravel/pint": "1.2.*",
         "phpstan/phpstan": "1.8.*",
         "rregeer/phpunit-coverage-check": "^0.3.1"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true,
+            "tbachert/spi": true
+        }
     }
 }

--- a/src/DNS/Client.php
+++ b/src/DNS/Client.php
@@ -243,10 +243,11 @@ class Client
                 $target = $this->decodeDomainName($packet, $offset);
                 return "Priority: {$priority[1]}, Weight: {$weight[1]}, Port: {$port[1]}, Target: {$target}";
             case 257: // CAA record
-                $flags = ord($packet[$offset]);
-                $offset++;
-                $tagLength = ord($packet[$offset]);
-                $offset++;
+                if ($rdlength < 2) {
+                    throw new Exception("CAA record too short (rdlength={$rdlength})");
+                }
+                $flags = ord($packet[$offset++]);
+                $tagLength = ord($packet[$offset++]);
                 $tag = substr($packet, $offset, $tagLength);
                 $offset += $tagLength;
                 $value = substr($packet, $offset, $rdlength - 2 - $tagLength);

--- a/src/DNS/Client.php
+++ b/src/DNS/Client.php
@@ -36,6 +36,7 @@ class Client
         'TXT'   => 16,
         'AAAA'  => 28,
         'SRV'   => 33,
+        'CAA'   => 257,
     ];
 
     public function __construct(string $server = '127.0.0.1', int $port = 53, int $timeout = 5)
@@ -241,6 +242,16 @@ class Client
                 $offset += 6;
                 $target = $this->decodeDomainName($packet, $offset);
                 return "Priority: {$priority[1]}, Weight: {$weight[1]}, Port: {$port[1]}, Target: {$target}";
+            case 257: // CAA record
+                $flags = ord($packet[$offset]);
+                $offset++;
+                $tagLength = ord($packet[$offset]);
+                $offset++;
+                $tag = substr($packet, $offset, $tagLength);
+                $offset += $tagLength;
+                $value = substr($packet, $offset, $rdlength - 2 - $tagLength);
+                $offset += $rdlength - 2 - $tagLength;
+                return "Flags: {$flags}, Tag: {$tag}, Value: {$value}";
             case 6: // SOA record
                 $mname = $this->decodeDomainName($packet, $offset);
                 $rname = $this->decodeDomainName($packet, $offset);

--- a/src/DNS/Client.php
+++ b/src/DNS/Client.php
@@ -251,7 +251,7 @@ class Client
                 $offset += $tagLength;
                 $value = substr($packet, $offset, $rdlength - 2 - $tagLength);
                 $offset += $rdlength - 2 - $tagLength;
-                return "Flags: {$flags}, Tag: {$tag}, Value: {$value}";
+                return "{$flags} {$tag} \"{$value}\"";
             case 6: // SOA record
                 $mname = $this->decodeDomainName($packet, $offset);
                 $rname = $this->decodeDomainName($packet, $offset);

--- a/tests/DNS/ClientTest.php
+++ b/tests/DNS/ClientTest.php
@@ -135,4 +135,20 @@ class ClientTest extends TestCase
         $records = $this->client->query('dev3.appwrite.io', 'NS');
         $this->assertCount(0, $records);
     }
+
+    public function testCAARecords(): void
+    {
+        $records = $this->client->query('github.com', 'CAA');
+
+        $this->assertCount(1, $records);
+        $this->assertEquals('github.com', $records[0]->getName());
+        $this->assertEquals('IN', $records[0]->getClass());
+        $this->assertIsNumeric($records[0]->getTTL());
+        $this->assertEquals('CAA', $records[0]->getTypeName());
+        
+        $rdata = $records[0]->getRdata();
+        $this->assertStringContainsString('Flags:', $rdata);
+        $this->assertStringContainsString('Tag:', $rdata);
+        $this->assertStringContainsString('Value:', $rdata);
+    }
 }

--- a/tests/DNS/ClientTest.php
+++ b/tests/DNS/ClientTest.php
@@ -145,7 +145,7 @@ class ClientTest extends TestCase
         $this->assertEquals('IN', $records[0]->getClass());
         $this->assertIsNumeric($records[0]->getTTL());
         $this->assertEquals('CAA', $records[0]->getTypeName());
-        
+
         $rdata = $records[0]->getRdata();
         $this->assertEquals('0 issue "pki.goog"', $rdata);
     }

--- a/tests/DNS/ClientTest.php
+++ b/tests/DNS/ClientTest.php
@@ -154,5 +154,10 @@ class ClientTest extends TestCase
         $this->assertCount(2, $records);
         $this->assertEquals('0 issue "letsencrypt.org"', $records[0]->getRdata());
         $this->assertEquals('0 issue "sectigo.com"', $records[1]->getRdata());
+
+        $records = $this->client->query('dev3.appwrite.io', 'CAA');
+
+        $this->assertCount(1, $records);
+        $this->assertEquals('255 issuewild "certainly.com;validationmethods=tls-alpn-01;retrytimeout=3600"', $records[0]->getRdata());
     }
 }

--- a/tests/DNS/ClientTest.php
+++ b/tests/DNS/ClientTest.php
@@ -138,17 +138,15 @@ class ClientTest extends TestCase
 
     public function testCAARecords(): void
     {
-        $records = $this->client->query('github.com', 'CAA');
+        $records = $this->client->query('google.com', 'CAA');
 
         $this->assertCount(1, $records);
-        $this->assertEquals('github.com', $records[0]->getName());
+        $this->assertEquals('google.com', $records[0]->getName());
         $this->assertEquals('IN', $records[0]->getClass());
         $this->assertIsNumeric($records[0]->getTTL());
         $this->assertEquals('CAA', $records[0]->getTypeName());
         
         $rdata = $records[0]->getRdata();
-        $this->assertStringContainsString('Flags:', $rdata);
-        $this->assertStringContainsString('Tag:', $rdata);
-        $this->assertStringContainsString('Value:', $rdata);
+        $this->assertEquals('0 issue "pki.goog"', $rdata);
     }
 }

--- a/tests/DNS/ClientTest.php
+++ b/tests/DNS/ClientTest.php
@@ -138,15 +138,21 @@ class ClientTest extends TestCase
 
     public function testCAARecords(): void
     {
-        $records = $this->client->query('google.com', 'CAA');
+        $records = $this->client->query('dev.appwrite.io', 'CAA');
 
         $this->assertCount(1, $records);
-        $this->assertEquals('google.com', $records[0]->getName());
+        $this->assertEquals('dev.appwrite.io', $records[0]->getName());
         $this->assertEquals('IN', $records[0]->getClass());
         $this->assertIsNumeric($records[0]->getTTL());
         $this->assertEquals('CAA', $records[0]->getTypeName());
 
         $rdata = $records[0]->getRdata();
-        $this->assertEquals('0 issue "pki.goog"', $rdata);
+        $this->assertEquals('0 issue "letsencrypt.org"', $rdata);
+
+        $records = $this->client->query('dev2.appwrite.io', 'CAA');
+
+        $this->assertCount(2, $records);
+        $this->assertEquals('0 issue "letsencrypt.org"', $records[0]->getRdata());
+        $this->assertEquals('0 issue "sectigo.com"', $records[1]->getRdata());
     }
 }

--- a/tests/DNS/ServerMemory.php
+++ b/tests/DNS/ServerMemory.php
@@ -77,6 +77,10 @@ $resolver->addRecord('dev2.appwrite.io', 'CAA', [
     'value' => 'issue "sectigo.com"'
 ]);
 
+$resolver->addRecord('dev3.appwrite.io', 'CAA', [
+    'value' => '255 issuewild "certainly.com;validationmethods=tls-alpn-01;retrytimeout=3600"'
+]);
+
 $resolver->addRecord('dev.appwrite.io', 'NS', [
     'value' => 'ns.appwrite.io',
     'ttl' => 60


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for querying and parsing CAA DNS records.

* **Tests**
  * Introduced new tests to verify correct handling and parsing of CAA DNS records.
  * Expanded in-memory DNS resolver with CAA records for enhanced testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->