### PR TITLE
Feat: support SOA record

### DIFF
--- a/src/DNS/Client.php
+++ b/src/DNS/Client.php
@@ -261,7 +261,7 @@ class Client
                     throw new Exception("Failed to parse SOA record.");
                 }
                 $offset += 20;
-                return "MNAME: {$mname}, RNAME: {$rname}, Serial: {$parts['serial']}, Refresh: {$parts['refresh']}, Retry: {$parts['retry']}, Expire: {$parts['expire']}, Minimum TTL: {$parts['minttl']}";
+                return "{$mname}. {$rname}. {$parts['serial']} {$parts['refresh']} {$parts['retry']} {$parts['expire']} {$parts['minttl']}";
             default:
                 $data = substr($packet, $offset, $rdlength);
                 if ($data == false) {

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -453,7 +453,7 @@ class Server
         // Parse SOA record data: "ns1.example.com. admin.example.com. 2025011801 7200 3600 1209600 1800"
         $parts = preg_split('/\s+/', trim($rdata));
 
-        if (count($parts) < 7) {
+        if (!$parts || count($parts) < 7) {
             throw new \Exception("Invalid SOA record format: {$rdata}");
         }
 

--- a/tests/DNS/ClientTest.php
+++ b/tests/DNS/ClientTest.php
@@ -160,4 +160,32 @@ class ClientTest extends TestCase
         $this->assertCount(1, $records);
         $this->assertEquals('255 issuewild "certainly.com;validationmethods=tls-alpn-01;retrytimeout=3600"', $records[0]->getRdata());
     }
+
+    public function testSOARecords(): void
+    {
+        $records = $this->client->query('appwrite.io', 'SOA');
+
+        $this->assertCount(1, $records);
+        $this->assertEquals('appwrite.io', $records[0]->getName());
+        $this->assertEquals('IN', $records[0]->getClass());
+        $this->assertIsNumeric($records[0]->getTTL());
+        $this->assertEquals(3600, $records[0]->getTTL());
+        $this->assertEquals('SOA', $records[0]->getTypeName());
+
+        $rdata = $records[0]->getRdata();
+        $this->assertStringContainsString('ns1.appwrite.io.', $rdata);
+        $this->assertStringContainsString('admin.appwrite.io.', $rdata);
+        $this->assertStringContainsString('2025011801', $rdata);
+
+        $records = $this->client->query('dev2.appwrite.io', 'SOA');
+
+        $this->assertCount(1, $records);
+        $rdata = $records[0]->getRdata();
+        $this->assertStringContainsString('ns1.dev2.appwrite.io.', $rdata);
+        $this->assertStringContainsString('admin.dev2.appwrite.io.', $rdata);
+        $this->assertStringContainsString('2025011802', $rdata);
+
+        $records = $this->client->query('dev3.appwrite.io', 'SOA');
+        $this->assertCount(0, $records);
+    }
 }

--- a/tests/DNS/RecordTest.php
+++ b/tests/DNS/RecordTest.php
@@ -178,4 +178,47 @@ final class RecordTest extends TestCase
         $this->assertSame(20, $record->getWeight());
         $this->assertSame(5060, $record->getPort());
     }
+
+    /**
+     * Test a record configured for SOA (Start of Authority).
+     */
+    public function testSOARecord(): void
+    {
+        $record = new Record();
+        $soaData = 'ns1.example.com. admin.example.com. 2025011801 7200 3600 1209600 1800';
+
+        $record->setName('example.com')
+               ->setTTL(3600)
+               ->setClass('IN')
+               ->setType(6) // SOA numeric code is 6.
+               ->setRdata($soaData);
+
+        $this->assertSame('example.com', $record->getName());
+        $this->assertSame(3600, $record->getTTL());
+        $this->assertSame('IN', $record->getClass());
+        $this->assertSame('SOA', $record->getTypeName());
+        $this->assertSame($soaData, $record->getRdata());
+    }
+
+    /**
+     * Test a record configured for SOA using string type.
+     */
+    public function testSOARecordWithStringType(): void
+    {
+        $record = new Record();
+        $soaData = 'ns1.example.com. admin.example.com. 2025011801 7200 3600 1209600 1800';
+
+        $record->setName('example.com')
+               ->setTTL(1800)
+               ->setClass('IN')
+               ->setType('SOA') // Using string instead of numeric code.
+               ->setRdata($soaData);
+
+        $this->assertSame('example.com', $record->getName());
+        $this->assertSame(1800, $record->getTTL());
+        $this->assertSame('IN', $record->getClass());
+        $this->assertSame(6, $record->getType()); // Should convert to numeric 6
+        $this->assertSame('SOA', $record->getTypeName());
+        $this->assertSame($soaData, $record->getRdata());
+    }
 }

--- a/tests/DNS/ServerMemory.php
+++ b/tests/DNS/ServerMemory.php
@@ -106,6 +106,15 @@ $resolver->addRecord('mail.appwrite.io', 'MX', [
     'priority' => 10
 ]);
 
+$resolver->addRecord('appwrite.io', 'SOA', [
+    'value' => 'ns1.appwrite.io. admin.appwrite.io. 2025011801 7200 3600 1209600 1800',
+    'ttl' => 3600
+]);
+
+$resolver->addRecord('dev2.appwrite.io', 'SOA', [
+    'value' => 'ns1.dev2.appwrite.io. admin.dev2.appwrite.io. 2025011802 14400 7200 2419200 3600'
+]);
+
 $dns = new Server($server, $resolver);
 $dns->setDebug(false);
 

--- a/tests/DNS/ZoneTest.php
+++ b/tests/DNS/ZoneTest.php
@@ -192,6 +192,30 @@ TXT;
         $this->assertEmpty($errors, 'Zero TTL should be accepted as valid integer TTL.');
     }
 
+    public function testValidateSOARecordEmptyData(): void
+    {
+        $z = new Zone();
+        $domain = 'example.com';
+
+        // Test with completely missing SOA data
+        $zoneFile = "example.com. 3600 IN SOA";
+
+        $errors = $z->validate($domain, $zoneFile);
+        $this->assertNotEmpty($errors, 'Expected validation error for SOA with empty data');
+        $this->assertStringContainsString('SOA record has empty data', $errors[0]);
+    }
+
+    public function testValidateSOARecordValidData(): void
+    {
+        $z = new Zone();
+        $domain = 'example.com';
+
+        $zoneFile = "@ IN SOA ns1.example.com. admin.example.com. 2025011801 7200 3600 1209600 1800\n";
+
+        $errors = $z->validate($domain, $zoneFile);
+        $this->assertEmpty($errors, 'Valid SOA record should not produce errors.');
+    }
+
     public function testImportWithDirectivesAndAutoQualification(): void
     {
         $z = new Zone();


### PR DESCRIPTION
- Support SOA records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DNS now recognizes NS and SOA queries and returns RFC-1035-compliant SOA responses with proper wire-format, TTL framing, and label/field validation.
* **Bug Fixes**
  * Validation flags SOA records with missing data and accepts correctly formed SOA entries.
* **Tests**
  * Added SOA tests (client, record parsing, zone validation) and updated in-memory test data for SOA scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->