### PR TITLE
chore: downgrade php 8.3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,5 +16,5 @@ jobs:
 
     - name: Run CodeQL
       run: |
-        docker run --rm -v $PWD:/app composer:2.8 sh -c \
+        docker run --rm -v $PWD:/app composer:2.7 sh -c \
         "composer install --profile --ignore-platform-reqs && composer check"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.8 as composer
+FROM composer:2.7 as composer
 
 ARG TESTING=false
 ENV TESTING=$TESTING

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Packagist Downloads](https://img.shields.io/packagist/dt/utopia-php/dns.svg)
 [![Discord](https://img.shields.io/discord/564160730845151244)](https://appwrite.io/discord)
 
-Utopia DNS is a modern PHP 8.4 toolkit for building DNS servers and clients. It provides a fully-typed DNS message encoder/decoder, pluggable resolvers, and telemetry hooks so you can stand up custom authoritative or proxy DNS services with minimal effort.
+Utopia DNS is a modern PHP 8.3 toolkit for building DNS servers and clients. It provides a fully-typed DNS message encoder/decoder, pluggable resolvers, and telemetry hooks so you can stand up custom authoritative or proxy DNS services with minimal effort.
 
 Although part of the [Utopia Framework](https://github.com/utopia-php/framework) family, the library is framework-agnostic and can be used in any PHP project.
 
@@ -15,7 +15,7 @@ Although part of the [Utopia Framework](https://github.com/utopia-php/framework)
 composer require utopia-php/dns
 ```
 
-The library requires PHP 8.4+ with the `ext-sockets` extension. The Swoole adapter additionally needs the `ext-swoole` extension.
+The library requires PHP 8.3+ with the `ext-sockets` extension. The Swoole adapter additionally needs the `ext-swoole` extension.
 
 ## Quick start
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr-4": {"Utopia\\DNS\\": "src/DNS"}
     },
     "require": {
-        "php": ">=8.4",
+        "php": ">=8.3",
         "utopia-php/console": "0.0.*",
         "utopia-php/telemetry": "0.1.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -3799,7 +3799,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4"
+        "php": ">=8.3"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/src/DNS/Message.php
+++ b/src/DNS/Message.php
@@ -52,7 +52,12 @@ final class Message
         if ($header->additionalCount !== count($additional)) {
             throw new \InvalidArgumentException('Invalid DNS response: additional count mismatch');
         }
-        if ($header->isResponse && $header->authoritative && !array_any($this->authority, fn ($record) => $record->type === Record::TYPE_SOA)) {
+        $soaAuthorityCount = count(array_filter(
+            $this->authority,
+            fn ($record) => $record->type === Record::TYPE_SOA
+        ));
+
+        if ($header->isResponse && $header->authoritative && $soaAuthorityCount < 1) {
             if ($header->responseCode === self::RCODE_NXDOMAIN) {
                 throw new \InvalidArgumentException('NXDOMAIN requires SOA in authority');
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum PHP version requirement from 8.4+ to 8.3+, allowing compatibility with earlier PHP versions.
  * Updated Docker image dependencies used in build and CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->