### PR TITLE
Trim whitespace from domain names

### DIFF
--- a/src/DNS/Message/Question.php
+++ b/src/DNS/Message/Question.php
@@ -13,7 +13,7 @@ final readonly class Question
         public int $type,
         public int $class = Record::CLASS_IN
     ) {
-        $this->name = strtolower($name);
+        $this->name = trim(strtolower($name));
     }
 
     /**

--- a/src/DNS/Message/Record.php
+++ b/src/DNS/Message/Record.php
@@ -120,7 +120,7 @@ final readonly class Record
         public ?int $weight = null,
         public ?int $port = null
     ) {
-        $this->name = strtolower($name);
+        $this->name = trim(strtolower($name));
     }
 
     /**

--- a/tests/unit/DNS/Message/QuestionTest.php
+++ b/tests/unit/DNS/Message/QuestionTest.php
@@ -61,4 +61,18 @@ final class QuestionTest extends TestCase
         $this->assertSame(Record::CLASS_IN, $parsedSecond->class);
         $this->assertSame(strlen($message), $offset);
     }
+
+    public function testConstructorTrimsWhitespaceFromName(): void
+    {
+        $question = new Question('  www.example.com  ', Record::TYPE_A, Record::CLASS_IN);
+
+        $this->assertSame('www.example.com', $question->name);
+    }
+
+    public function testConstructorTrimsTabsAndNewlinesFromName(): void
+    {
+        $question = new Question("\t\nwww.example.com\r\n", Record::TYPE_A, Record::CLASS_IN);
+
+        $this->assertSame('www.example.com', $question->name);
+    }
 }

--- a/tests/unit/DNS/Message/RecordTest.php
+++ b/tests/unit/DNS/Message/RecordTest.php
@@ -482,4 +482,44 @@ final class RecordTest extends TestCase
         $this->assertSame(Record::TYPE_TXT, $decoded->type);
         $this->assertSame(600, $decoded->ttl);
     }
+
+    public function testConstructorTrimsWhitespaceFromName(): void
+    {
+        $record = new Record(
+            name: '  example.com  ',
+            type: Record::TYPE_A,
+            class: Record::CLASS_IN,
+            ttl: 300,
+            rdata: '93.184.216.34'
+        );
+
+        $this->assertSame('example.com', $record->name);
+    }
+
+    public function testConstructorTrimsTabsAndNewlinesFromName(): void
+    {
+        $record = new Record(
+            name: "\t\nexample.com\r\n",
+            type: Record::TYPE_A,
+            class: Record::CLASS_IN,
+            ttl: 300,
+            rdata: '93.184.216.34'
+        );
+
+        $this->assertSame('example.com', $record->name);
+    }
+
+    public function testWithNameTrimsWhitespace(): void
+    {
+        $record = new Record(
+            name: 'example.com',
+            type: Record::TYPE_A,
+            class: Record::CLASS_IN,
+            ttl: 300,
+            rdata: '93.184.216.34'
+        );
+
+        $renamed = $record->withName('  other.com  ');
+        $this->assertSame('other.com', $renamed->name);
+    }
 }


### PR DESCRIPTION
## Summary
- Automatically `trim()` domain names in `Record` and `Question` constructors to strip leading/trailing whitespace
- Added tests for whitespace, tabs, and newline trimming in both classes

## Test plan
- [x] Unit tests pass (`testConstructorTrimsWhitespaceFromName`, `testConstructorTrimsTabsAndNewlinesFromName`, `testWithNameTrimsWhitespace`)
- [ ] Verify no regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)