### PR TITLE
Update utopia-php/span to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "utopia-php/span": "1.1.*",
+        "utopia-php/span": "3.0.*",
         "utopia-php/telemetry": "*",
         "utopia-php/validators": "0.*",
         "utopia-php/domains": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7732004aa2671415906ca3cc6950da8e",
+    "content-hash": "326929c0d5fd258432f2441f06801968",
     "packages": [
         {
             "name": "brick/math",
@@ -2108,16 +2108,16 @@
         },
         {
             "name": "utopia-php/span",
-            "version": "1.1.5",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/span.git",
-                "reference": "028406940ca92bdc88099f0b1a123a3b2cbdd4e5"
+                "reference": "97f0ab6e9125c000262f8b5b007423d11fd1a9b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/span/zipball/028406940ca92bdc88099f0b1a123a3b2cbdd4e5",
-                "reference": "028406940ca92bdc88099f0b1a123a3b2cbdd4e5",
+                "url": "https://api.github.com/repos/utopia-php/span/zipball/97f0ab6e9125c000262f8b5b007423d11fd1a9b3",
+                "reference": "97f0ab6e9125c000262f8b5b007423d11fd1a9b3",
                 "shasum": ""
             },
             "require": {
@@ -2146,9 +2146,9 @@
             "description": "Simple span tracing library for PHP with coroutine support",
             "support": {
                 "issues": "https://github.com/utopia-php/span/issues",
-                "source": "https://github.com/utopia-php/span/tree/1.1.5"
+                "source": "https://github.com/utopia-php/span/tree/3.0.1"
             },
-            "time": "2026-02-13T18:00:11+00:00"
+            "time": "2026-05-13T11:53:06+00:00"
         },
         {
             "name": "utopia-php/telemetry",

--- a/src/DNS/Server.php
+++ b/src/DNS/Server.php
@@ -170,6 +170,7 @@ class Server
 
         $question = null;
         $response = null;
+        $level = null;
 
         try {
             // 1. Parse Message.
@@ -179,7 +180,7 @@ class Server
             } catch (PartialDecodingException $e) {
                 $this->handleError($e);
 
-                $span->set('level', 'warn');
+                $level = 'warn';
                 $response = Message::response(
                     $e->getHeader(),
                     Message::RCODE_FORMERR,
@@ -208,7 +209,7 @@ class Server
 
             $question = $query->questions[0] ?? null;
             if ($question === null) {
-                $span->set('level', 'warn');
+                $level = 'warn';
                 $response = Message::response(
                     $query->header,
                     Message::RCODE_FORMERR,
@@ -281,7 +282,7 @@ class Server
                 $span->set('dns.response.code', $response->header->responseCode);
                 $span->set('dns.response.answer_count', $response->header->answerCount);
             }
-            $span->finish();
+            $span->finish($level);
         }
     }
 

--- a/tests/resources/server.php
+++ b/tests/resources/server.php
@@ -19,7 +19,7 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') !== __FILE__) {
 }
 
 Span::setStorage(new Storage\Coroutine());
-Span::addExporter(new Exporter\Stdout());
+Span::setExporters(new Exporter\Stdout());
 
 $port = (int) (getenv('PORT') ?: 5300);
 $server = new Swoole('0.0.0.0', $port);


### PR DESCRIPTION
## Summary

Updates `utopia-php/span` from `1.1.*` to `3.0.*` (resolves to 3.0.1) and migrates the breaking API changes.

## Breaking changes migrated

- **`Span::addExporter()` removed** → replaced with the variadic `Span::setExporters(...)` (`tests/resources/server.php`).
- **`finish()` now owns the `level` attribute** → it sets `level` itself (from error presence, or an optional `finish(?string $level)` argument), so the old `$span->set('level', 'warn')` calls would be silently clobbered. `onPacket()` now tracks the level in a variable and passes it through as `$span->finish($level)` (`src/DNS/Server.php`).

## Verification

- PHPStan (level max): clean.
- PHPUnit: 186 tests / 776 assertions pass against the Swoole server (`docker compose`).
- Confirmed live span output uses the 3.0 format: `{"level":"info","action":"dns.worker.start",...}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)